### PR TITLE
Support for local dependencies

### DIFF
--- a/docs/packindex.md
+++ b/docs/packindex.md
@@ -14,6 +14,7 @@ In order to get Multipacks knows your pack info, you need to add ``multipacks.js
     "include": {
         "otherpackid": ">=1.0.0",
         "anotherpackid": "<15.1.2",
+        "localpack": "file:../localfolder",
         "...": "..."
     },
     "ignore": [
@@ -39,7 +40,13 @@ This is your pack version (not game version, which is in ``gameVersion`` field).
 The targetted game version. Putting ``>``, ``<``, ``>=`` or ``<=`` doesn't really do anything... for now.
 
 ### ``include`` (Optional)
-This field is a JSON object, with its key as pack id and its value is a version filter. ``>``, ``<``, ``>=`` and ``<=`` version prefixes does works so you can target any pack versions in the range.
+This field is a JSON object, with its key as pack id and its value is a version filter or a path to file, prefixed by ``file:``. For versions, ``>``, ``<``, ``>=`` and ``<=`` version prefixes does works so you can target any pack versions in the range. For local files, the current path will always be at the pack folder, so ``./mypack`` will pick the ``mypack`` folder inside your pack.
+
+```
+>=7.2.7
+file:./mypack_items
+file:./mypack_blocks
+```
 
 ### ``ignore`` (Optional)
 An array that contains all paths to ignore. By default, Multipacks will excludes these files from package:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -70,6 +70,7 @@ Open ``myPack/`` and you will see all the pack contents, including resources pac
     "include": {
         "otherpackid": ">=1.0.0",
         "anotherpackid": "<15.1.2",
+        "localpack": "file:../myLocalPack",
         "...": "..."
     }
 }

--- a/multipacks-cli/src/main/java/multipacks/cli/MultipacksCLI.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/MultipacksCLI.java
@@ -258,7 +258,7 @@ public class MultipacksCLI {
 
 			if (index.include != null && index.include.length > 0) {
 				System.out.println(" - " + index.include.length + (index.include.length == 1? " depenency" : " depenencies"));
-				for (PackIdentifier i : index.include) System.out.println("   + " + i.id + " " + i.version);
+				for (PackIdentifier i : index.include) System.out.println("   + " + i.id + " " + (i.folder != null? "Local(" + i.folder + ")" : i.version));
 			}
 
 			File assets = pack.getAssetsRoot();
@@ -456,6 +456,14 @@ public class MultipacksCLI {
 
 		try {
 			Pack pack = new Pack(packDir);
+
+			if (pack.getIndex().hasLocalReference()) {
+				System.err.println("Cannot install pack with local references");
+				System.err.println("Please check multipacks.json and ensure that 'include' section does not contains 'file:...' in dependency version field");
+				System.exit(1);
+				return;
+			}
+
 			System.out.println("Installing " + pack.getIndex().id + " v" + pack.getIndex().packVersion + " to your repository...");
 			System.out.println("Current repository is " + selectedRepository);
 			uploadable.putPack(pack);

--- a/multipacks-engine/src/main/java/multipacks/management/LocalRepository.java
+++ b/multipacks-engine/src/main/java/multipacks/management/LocalRepository.java
@@ -54,6 +54,7 @@ public class LocalRepository extends PacksRepository implements PacksUploadable 
 
 	@Override
 	public boolean putPack(Pack pack, boolean force) throws IllegalAccessException {
+		if (pack.getIndex().hasLocalReference()) return false;
 		File packDir = getPackDir(pack.getIdentifier());
 		if (packDir.exists()) return false;
 

--- a/multipacks-engine/src/main/java/multipacks/packs/PackIdentifier.java
+++ b/multipacks-engine/src/main/java/multipacks/packs/PackIdentifier.java
@@ -20,15 +20,27 @@ import multipacks.versioning.Version;
 public class PackIdentifier {
 	public final String id;
 	public final Version version;
+	public final String folder;
 
 	public PackIdentifier(String id, Version version) {
 		this.id = id;
 		this.version = version;
+		this.folder = null;
+	}
+
+	public PackIdentifier(String id, String folder) {
+		this.id = id;
+		this.version = null;
+		this.folder = folder;
+	}
+
+	public static PackIdentifier fromString(String id, String location) {
+		return location.startsWith("file:")? new PackIdentifier(id, location.substring(5)) : new PackIdentifier(id, new Version(location)); 
 	}
 
 	@Override
 	public String toString() {
-		return id + ": " + version;
+		return id + ": " + (folder != null? "file:" + folder : version);
 	}
 
 	@Override

--- a/multipacks-engine/src/main/java/multipacks/packs/PackIndex.java
+++ b/multipacks-engine/src/main/java/multipacks/packs/PackIndex.java
@@ -16,6 +16,7 @@
 package multipacks.packs;
 
 import java.util.Map.Entry;
+import java.util.stream.Stream;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -55,7 +56,7 @@ public class PackIndex {
 			int i = 0;
 
 			for (Entry<String, JsonElement> entry : includeMap.entrySet()) {
-				ids[i++] = new PackIdentifier(entry.getKey(), new Version(entry.getValue().getAsString()));
+				ids[i++] = PackIdentifier.fromString(entry.getKey(), entry.getValue().getAsString());
 			}
 
 			return ids;
@@ -74,6 +75,14 @@ public class PackIndex {
 			return ignore;
 		}, null);
 		return out;
+	}
+
+	/**
+	 * Check if the pack index have local references. Pack with local references are not allowed to upload
+	 * to packs repository, simply because it's impossible (duh).
+	 */
+	public boolean hasLocalReference() {
+		return Stream.of(include).anyMatch(v -> v.folder != null);
 	}
 
 	public JsonObject toJson() {


### PR DESCRIPTION
With this PR, user can link to local pack by using ``file:`` instead of pack version. An example would be ``file:../myPack`` or ``file:./mychildrenpack`` (so it would act like "submodule")