### PR TITLE
Fix dependency licenses are not being copied to "licenses/" folder

### DIFF
--- a/multipacks-engine/src/main/java/multipacks/bundling/BundleInclude.java
+++ b/multipacks-engine/src/main/java/multipacks/bundling/BundleInclude.java
@@ -18,5 +18,6 @@ package multipacks.bundling;
 public enum BundleInclude {
 	NONE,
 	RESOURCES,
+	LICENSES,
 	DATA;
 }

--- a/multipacks-engine/src/main/java/multipacks/bundling/PackBundler.java
+++ b/multipacks-engine/src/main/java/multipacks/bundling/PackBundler.java
@@ -106,6 +106,7 @@ public class PackBundler {
 		for (BundleInclude incl : includes) {
 			if (incl == BundleInclude.RESOURCES && path.startsWith("assets/")) return true;
 			if (incl == BundleInclude.DATA && path.startsWith("data/")) return true;
+			if (incl == BundleInclude.LICENSES && path.startsWith("licenses/")) return true;
 		}
 
 		return false;


### PR DESCRIPTION
Previously, some licenses are not being copied to ``pack.zip/licenses/`` folder. This PR fix this by introducing ``BundleInclude.LICENSES`` and add ``licenses/`` when this type is present. It does not prevent from pack that's being built against from emitting its license file.