### PR TITLE
Plugins for Multipacks CLI

### DIFF
--- a/multipacks-cli/src/main/java/multipacks/cli/Main.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/Main.java
@@ -24,6 +24,8 @@ import multipacks.bundling.BundleIgnore;
 import multipacks.bundling.BundleInclude;
 import multipacks.management.PacksRepository;
 import multipacks.packs.PackIdentifier;
+import multipacks.plugins.MultipacksDefaultPlugin;
+import multipacks.plugins.MultipacksPlugin;
 import multipacks.versioning.Version;
 
 public class Main {
@@ -63,8 +65,14 @@ public class Main {
 			System.out.println("        Available pack types: " + String.join(", ", Stream.of(BundleInclude.values()).map(v -> v.toString().toLowerCase()).toArray(String[]::new)));
 			System.out.println("  -W  --watch");
 			System.out.println("        Watch for any changes (usable with pack build)");
+			System.out.println("      --plugin </path/to/plugin.jar>");
+			System.out.println("        Load Multipacks Engine plugin from a JAR file");
+			System.out.println("        By default, this will not load any plugin but the integrated one");
 			return;
 		}
+
+		// Load plugins
+		MultipacksPlugin.loadPlugin(new MultipacksDefaultPlugin());
 
 		MultipacksCLI cli = new MultipacksCLI(currentPlatform);
 		List<String> regularArguments = new ArrayList<>();
@@ -146,6 +154,10 @@ public class Main {
 				cli.bundleIncludes = includes;
 			} else if (s.equals("-W") || s.equals("--watch")) {
 				cli.watchInputs = true;
+			} else if (s.equals("--plugin")) {
+				String plugin = args[++i];
+				System.out.println("Plugin: " + plugin);
+				MultipacksPlugin.loadJarPlugin(new File(plugin));
 			} else {
 				System.err.println("Unknown option: " + s);
 				System.exit(1);

--- a/multipacks-engine/src/main/java/multipacks/management/PacksRepository.java
+++ b/multipacks-engine/src/main/java/multipacks/management/PacksRepository.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import multipacks.packs.Pack;
 import multipacks.packs.PackIdentifier;
 import multipacks.packs.PackIndex;
+import multipacks.plugins.MultipacksPlugin;
 
 public abstract class PacksRepository {
 	/**
@@ -61,7 +62,10 @@ public abstract class PacksRepository {
 	 * Parse repository string.
 	 */
 	public static PacksRepository parseRepository(File root, String str) {
-		if (str.startsWith("file:")) return new LocalRepository(new File(root, str.substring(5).replace('/', File.separatorChar)));
+		for (MultipacksPlugin plug : MultipacksPlugin.PLUGINS) {
+			PacksRepository repo = plug.parseRepository(root, str);
+			if (repo != null) return repo;
+		}
 		return null;
 	}
 }

--- a/multipacks-engine/src/main/java/multipacks/plugins/MultipacksDefaultPlugin.java
+++ b/multipacks-engine/src/main/java/multipacks/plugins/MultipacksDefaultPlugin.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package multipacks.plugins;
 
 import java.io.File;

--- a/multipacks-engine/src/main/java/multipacks/plugins/MultipacksDefaultPlugin.java
+++ b/multipacks-engine/src/main/java/multipacks/plugins/MultipacksDefaultPlugin.java
@@ -1,0 +1,31 @@
+package multipacks.plugins;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.function.Function;
+
+import com.google.gson.JsonObject;
+
+import multipacks.management.LocalRepository;
+import multipacks.management.PacksRepository;
+import multipacks.postprocess.CopyPass;
+import multipacks.postprocess.DeletePass;
+import multipacks.postprocess.IncludePass;
+import multipacks.postprocess.MovePass;
+import multipacks.postprocess.PostProcessPass;
+
+public class MultipacksDefaultPlugin implements MultipacksPlugin {
+	@Override
+	public PacksRepository parseRepository(File root, String uri) {
+		if (uri.startsWith("file:")) return new LocalRepository(new File(uri.substring(5)));
+		return null;
+	}
+
+	@Override
+	public void registerPostProcessPasses(HashMap<String, Function<JsonObject, PostProcessPass>> reg) {
+		reg.put("include", IncludePass::new);
+		reg.put("move", MovePass::new);
+		reg.put("delete", DeletePass::new);
+		reg.put("copy", CopyPass::new);
+	}
+}

--- a/multipacks-engine/src/main/java/multipacks/plugins/MultipacksPlugin.java
+++ b/multipacks-engine/src/main/java/multipacks/plugins/MultipacksPlugin.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package multipacks.plugins;
 
 import java.io.File;

--- a/multipacks-engine/src/main/java/multipacks/plugins/MultipacksPlugin.java
+++ b/multipacks-engine/src/main/java/multipacks/plugins/MultipacksPlugin.java
@@ -1,0 +1,71 @@
+package multipacks.plugins;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Constructor;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.function.Function;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import multipacks.management.PacksRepository;
+import multipacks.postprocess.PostProcessPass;
+import multipacks.utils.Selects;
+
+public interface MultipacksPlugin {
+	default void onLoad() {}
+
+	default PacksRepository parseRepository(File root, String uri) { return null; }
+	default void registerPostProcessPasses(HashMap<String, Function<JsonObject, PostProcessPass>> reg) {}
+
+	ArrayList<MultipacksPlugin> PLUGINS = new ArrayList<>();
+
+	static void loadPlugin(MultipacksPlugin plugin) {
+		plugin.onLoad();
+		plugin.registerPostProcessPasses(PostProcessPass.REGISTRY);
+		PLUGINS.add(plugin);
+	}
+
+	static void loadJarPlugin(URL jarUrl) throws IOException {
+		try (URLClassLoader clsLoader = new URLClassLoader(new URL[] { jarUrl }, MultipacksPlugin.class.getClassLoader())) {
+			InputStream in = clsLoader.getResourceAsStream("multipacks.plugin.json");
+			if (in == null) throw new PluginLoadException("Missing multipacks.plugin.json inside " + jarUrl + " plugin");
+			JsonElement json = new JsonParser().parse(new InputStreamReader(in));
+			in.close();
+
+			String mainClass;
+
+			if (json.isJsonPrimitive()) {
+				mainClass = json.getAsString();
+			} else if (json.isJsonObject()) {
+				mainClass = Selects.nonNull(json.getAsJsonObject().get("main"), "Missing 'main' in multipacks.plugin.json").getAsString();
+			} else throw new PluginLoadException("Cannot read main class inside multipacks.plugin.json in " + jarUrl + " plugin");
+
+			try {
+				Class<?> cls = Class.forName(mainClass, true, clsLoader);
+				Constructor<?> ctor = cls.getDeclaredConstructor();
+				Object obj = ctor.newInstance();
+
+				if (obj instanceof MultipacksPlugin plugin) loadPlugin(plugin);
+				else System.err.println("Warning: Plugin '" + jarUrl + "' have its main class not an instance of MultipacksPlugin");
+			} catch (Exception e) {
+				throw new PluginLoadException("Cannot load plugin " + jarUrl, e);
+			}
+		}
+	}
+
+	static void loadJarPlugin(File jar) {
+		try {
+			loadJarPlugin(jar.toURI().toURL());
+		} catch (Exception e) {
+			throw new PluginLoadException("Cannot load plugin " + jar.toString(), e);
+		}
+	}
+}

--- a/multipacks-engine/src/main/java/multipacks/plugins/PluginLoadException.java
+++ b/multipacks-engine/src/main/java/multipacks/plugins/PluginLoadException.java
@@ -1,0 +1,13 @@
+package multipacks.plugins;
+
+public class PluginLoadException extends RuntimeException {
+	private static final long serialVersionUID = -818588508988080084L;
+
+	public PluginLoadException(String message) {
+		super(message);
+	}
+
+	public PluginLoadException(String message, Throwable from) {
+		super(message, from);
+	}
+}

--- a/multipacks-engine/src/main/java/multipacks/plugins/PluginLoadException.java
+++ b/multipacks-engine/src/main/java/multipacks/plugins/PluginLoadException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package multipacks.plugins;
 
 public class PluginLoadException extends RuntimeException {

--- a/multipacks-engine/src/main/java/multipacks/postprocess/PostProcessPass.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/PostProcessPass.java
@@ -59,12 +59,4 @@ public abstract class PostProcessPass {
 			else pass.apply(fs, result, logger);
 		}
 	}
-
-	static {
-		// Basic file operations
-		REGISTRY.put("include", IncludePass::new);
-		REGISTRY.put("move", MovePass::new);
-		REGISTRY.put("delete", DeletePass::new);
-		REGISTRY.put("copy", CopyPass::new);
-	}
 }

--- a/multipacks-sample-plugin/build.gradle
+++ b/multipacks-sample-plugin/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation project(':multipacks-engine')
+}

--- a/multipacks-sample-plugin/src/main/java/multipacks/sampleplugin/SamplePlugin.java
+++ b/multipacks-sample-plugin/src/main/java/multipacks/sampleplugin/SamplePlugin.java
@@ -1,0 +1,10 @@
+package multipacks.sampleplugin;
+
+import multipacks.plugins.MultipacksPlugin;
+
+public class SamplePlugin implements MultipacksPlugin {
+	@Override
+	public void onLoad() {
+		System.out.println("Hello world!");
+	}
+}

--- a/multipacks-sample-plugin/src/main/java/multipacks/sampleplugin/SamplePlugin.java
+++ b/multipacks-sample-plugin/src/main/java/multipacks/sampleplugin/SamplePlugin.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package multipacks.sampleplugin;
 
 import multipacks.plugins.MultipacksPlugin;

--- a/multipacks-sample-plugin/src/main/resources/multipacks.plugin.json
+++ b/multipacks-sample-plugin/src/main/resources/multipacks.plugin.json
@@ -1,0 +1,5 @@
+{
+    "name": "Sample plugin",
+    "author": "nahkd123",
+    "main": "multipacks.sampleplugin.SamplePlugin"
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,3 +11,4 @@ rootProject.name = 'multipacks'
 include('multipacks-engine')
 include('multipacks-cli')
 include('multipacks-spigot')
+include('multipacks-sample-plugin')


### PR DESCRIPTION
Multipacks for Spigot will remain untouched. Any Spigot plugins that uses Multipacks can load Multipacks CLI plugins using this simple code:

```java
for (File f : getDataFolder().listFiles()) MultipacksPlugin.loadJarPlugin(f);
```