### PR TITLE
Adding back post processing passes (was transform passes previously)

### DIFF
--- a/multipacks-engine/src/main/java/multipacks/plugins/MultipacksDefaultPlugin.java
+++ b/multipacks-engine/src/main/java/multipacks/plugins/MultipacksDefaultPlugin.java
@@ -30,6 +30,7 @@ import multipacks.postprocess.basic.DeletePass;
 import multipacks.postprocess.basic.IncludePass;
 import multipacks.postprocess.basic.MovePass;
 import multipacks.postprocess.font.FontIconsPass;
+import multipacks.postprocess.overlays.OverlayPass;
 
 public class MultipacksDefaultPlugin implements MultipacksPlugin {
 	@Override
@@ -47,5 +48,6 @@ public class MultipacksDefaultPlugin implements MultipacksPlugin {
 
 		reg.put("font-icons", FontIconsPass::new);
 		reg.put("atlas", AtlasPass::new);
+		reg.put("overlay", OverlayPass::new);
 	}
 }

--- a/multipacks-engine/src/main/java/multipacks/plugins/MultipacksDefaultPlugin.java
+++ b/multipacks-engine/src/main/java/multipacks/plugins/MultipacksDefaultPlugin.java
@@ -23,11 +23,11 @@ import com.google.gson.JsonObject;
 
 import multipacks.management.LocalRepository;
 import multipacks.management.PacksRepository;
-import multipacks.postprocess.CopyPass;
-import multipacks.postprocess.DeletePass;
-import multipacks.postprocess.IncludePass;
-import multipacks.postprocess.MovePass;
 import multipacks.postprocess.PostProcessPass;
+import multipacks.postprocess.basic.CopyPass;
+import multipacks.postprocess.basic.DeletePass;
+import multipacks.postprocess.basic.IncludePass;
+import multipacks.postprocess.basic.MovePass;
 
 public class MultipacksDefaultPlugin implements MultipacksPlugin {
 	@Override

--- a/multipacks-engine/src/main/java/multipacks/plugins/MultipacksDefaultPlugin.java
+++ b/multipacks-engine/src/main/java/multipacks/plugins/MultipacksDefaultPlugin.java
@@ -24,6 +24,7 @@ import com.google.gson.JsonObject;
 import multipacks.management.LocalRepository;
 import multipacks.management.PacksRepository;
 import multipacks.postprocess.PostProcessPass;
+import multipacks.postprocess.atlas.AtlasPass;
 import multipacks.postprocess.basic.CopyPass;
 import multipacks.postprocess.basic.DeletePass;
 import multipacks.postprocess.basic.IncludePass;
@@ -45,5 +46,6 @@ public class MultipacksDefaultPlugin implements MultipacksPlugin {
 		reg.put("copy", CopyPass::new);
 
 		reg.put("font-icons", FontIconsPass::new);
+		reg.put("atlas", AtlasPass::new);
 	}
 }

--- a/multipacks-engine/src/main/java/multipacks/plugins/MultipacksDefaultPlugin.java
+++ b/multipacks-engine/src/main/java/multipacks/plugins/MultipacksDefaultPlugin.java
@@ -28,6 +28,7 @@ import multipacks.postprocess.basic.CopyPass;
 import multipacks.postprocess.basic.DeletePass;
 import multipacks.postprocess.basic.IncludePass;
 import multipacks.postprocess.basic.MovePass;
+import multipacks.postprocess.font.FontIconsPass;
 
 public class MultipacksDefaultPlugin implements MultipacksPlugin {
 	@Override
@@ -42,5 +43,7 @@ public class MultipacksDefaultPlugin implements MultipacksPlugin {
 		reg.put("move", MovePass::new);
 		reg.put("delete", DeletePass::new);
 		reg.put("copy", CopyPass::new);
+
+		reg.put("font-icons", FontIconsPass::new);
 	}
 }

--- a/multipacks-engine/src/main/java/multipacks/postprocess/atlas/AtlasPass.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/atlas/AtlasPass.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package multipacks.postprocess.atlas;
 
 import java.awt.image.BufferedImage;

--- a/multipacks-engine/src/main/java/multipacks/postprocess/atlas/AtlasPass.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/atlas/AtlasPass.java
@@ -1,0 +1,61 @@
+package multipacks.postprocess.atlas;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map.Entry;
+
+import javax.imageio.ImageIO;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import multipacks.bundling.BundleResult;
+import multipacks.postprocess.PostProcessPass;
+import multipacks.utils.Selects;
+import multipacks.utils.logging.AbstractMPLogger;
+import multipacks.vfs.Path;
+import multipacks.vfs.VirtualFs;
+
+public class AtlasPass extends PostProcessPass {
+	private Path from, to;
+	private AtlasTemplate[] templates;
+
+	public AtlasPass(JsonObject config) {
+		from = new Path(Selects.nonNull(config.get("from"), "'from' is empty").getAsString());
+		to = new Path(Selects.nonNull(config.get("to"), "'to' is empty").getAsString());
+
+		JsonObject templatesMap = Selects.nonNull(config.get("templates"), "'templates' is empty").getAsJsonObject();
+		templates = new AtlasTemplate[templatesMap.size()];
+		int pointer = 0;
+
+		for (Entry<String, JsonElement> e : templatesMap.entrySet()) {
+			templates[pointer++] = new AtlasTemplate(e.getKey(), e.getValue().getAsJsonObject());
+		}
+	}
+
+	@Override
+	public void apply(VirtualFs fs, BundleResult result, AbstractMPLogger logger) throws IOException {
+		for (Path src : fs.ls(from)) {
+			String[] split = src.fileName().split("\\.");
+			Path base = split.length > 1? new Path(src.toString().substring(0, src.toString().length() - split[split.length - 1].length() - 1)) : src;
+
+			InputStream in = fs.getStream(src);
+			BufferedImage srcImg = ImageIO.read(in);
+			in.close();
+
+			for (AtlasTemplate t : templates) {
+				Path dest = to.join(base.fileName() + t.suffix + ".png");
+				BufferedImage dstImg = t.getFrom(srcImg);
+
+				ByteArrayOutputStream o = new ByteArrayOutputStream();
+				ImageIO.write(dstImg, "PNG", o);
+				o.flush();
+				fs.write(dest, o.toByteArray());
+			}
+		}
+
+		fs.delete(from);
+	}
+}

--- a/multipacks-engine/src/main/java/multipacks/postprocess/atlas/AtlasTemplate.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/atlas/AtlasTemplate.java
@@ -1,0 +1,37 @@
+package multipacks.postprocess.atlas;
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+
+import com.google.gson.JsonObject;
+
+import multipacks.utils.Selects;
+
+public class AtlasTemplate {
+	public final String suffix;
+	public final int x, y, width, height;
+
+	public AtlasTemplate(String suffix, int x, int y, int width, int height) {
+		this.suffix = suffix;
+		this.x = x;
+		this.y = y;
+		this.width = width;
+		this.height = height;
+	}
+
+	public AtlasTemplate(String suffix, JsonObject json) {
+		this.suffix = suffix;
+		this.x = Selects.nonNull(json.get("x"), "'x' is empty").getAsInt();
+		this.y = Selects.nonNull(json.get("y"), "'y' is empty").getAsInt();
+		this.width = Selects.nonNull(json.get("width"), "'width' is empty").getAsInt();
+		this.height = Selects.nonNull(json.get("height"), "'height' is empty").getAsInt();
+	}
+
+	public BufferedImage getFrom(BufferedImage img) {
+		BufferedImage dest = new BufferedImage(width, height, BufferedImage.TYPE_4BYTE_ABGR);
+		Graphics2D g = dest.createGraphics();
+		g.drawImage(img, 0, 0, width, height, x, y, x + width, y + height, null);
+		g.dispose();
+		return dest;
+	}
+}

--- a/multipacks-engine/src/main/java/multipacks/postprocess/atlas/AtlasTemplate.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/atlas/AtlasTemplate.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package multipacks.postprocess.atlas;
 
 import java.awt.Graphics2D;

--- a/multipacks-engine/src/main/java/multipacks/postprocess/basic/CopyPass.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/basic/CopyPass.java
@@ -13,29 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package multipacks.postprocess;
+package multipacks.postprocess.basic;
 
 import java.io.IOException;
 
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import multipacks.bundling.BundleResult;
+import multipacks.postprocess.PostProcessPass;
 import multipacks.utils.Selects;
 import multipacks.utils.logging.AbstractMPLogger;
 import multipacks.vfs.Path;
 import multipacks.vfs.VirtualFs;
 
-public class IncludePass extends PostProcessPass {
-	private Path file;
+public class CopyPass extends PostProcessPass {
+	private Path from;
+	private Path to;
 
-	public IncludePass(JsonObject config) {
-		file = new Path(Selects.nonNull(config.get("file"), "'file' is empty").getAsString());
+	public CopyPass(JsonObject config) {
+		from = new Path(Selects.nonNull(config.get("from"), "'from' is empty").getAsString());
+		to = new Path(Selects.nonNull(config.get("to"), "'to' is empty").getAsString());
 	}
 
 	@Override
 	public void apply(VirtualFs fs, BundleResult result, AbstractMPLogger logger) throws IOException {
-		JsonElement json = fs.readJson(file);
-		PostProcessPass.apply(json, fs, result, logger);
+		for (Path pFrom : fs.ls(from)) {
+			String tail = pFrom.toString().substring(from.toString().length() + 1);
+			Path pTo = Path.join(to, new Path(tail));
+			byte[] bs = fs.read(pFrom);
+			fs.write(pTo, bs);
+		}
 	}
 }

--- a/multipacks-engine/src/main/java/multipacks/postprocess/basic/DeletePass.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/basic/DeletePass.java
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package multipacks.postprocess;
+package multipacks.postprocess.basic;
 
 import java.io.IOException;
 
 import com.google.gson.JsonObject;
 
 import multipacks.bundling.BundleResult;
+import multipacks.postprocess.PostProcessPass;
 import multipacks.utils.Selects;
 import multipacks.utils.logging.AbstractMPLogger;
 import multipacks.vfs.Path;

--- a/multipacks-engine/src/main/java/multipacks/postprocess/basic/IncludePass.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/basic/IncludePass.java
@@ -13,35 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package multipacks.postprocess;
+package multipacks.postprocess.basic;
 
 import java.io.IOException;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import multipacks.bundling.BundleResult;
+import multipacks.postprocess.PostProcessPass;
 import multipacks.utils.Selects;
 import multipacks.utils.logging.AbstractMPLogger;
 import multipacks.vfs.Path;
 import multipacks.vfs.VirtualFs;
 
-public class MovePass extends PostProcessPass {
-	private Path from;
-	private Path to;
+public class IncludePass extends PostProcessPass {
+	private Path file;
 
-	public MovePass(JsonObject config) {
-		from = new Path(Selects.nonNull(config.get("from"), "'from' is empty").getAsString());
-		to = new Path(Selects.nonNull(config.get("to"), "'to' is empty").getAsString());
+	public IncludePass(JsonObject config) {
+		file = new Path(Selects.nonNull(config.get("file"), "'file' is empty").getAsString());
 	}
 
 	@Override
 	public void apply(VirtualFs fs, BundleResult result, AbstractMPLogger logger) throws IOException {
-		for (Path pFrom : fs.ls(from)) {
-			String tail = pFrom.toString().substring(from.toString().length() + 1);
-			Path pTo = Path.join(to, new Path(tail));
-			byte[] bs = fs.read(pFrom);
-			fs.write(pTo, bs);
-			fs.delete(pFrom);
-		}
+		JsonElement json = fs.readJson(file);
+		PostProcessPass.apply(json, fs, result, logger);
 	}
 }

--- a/multipacks-engine/src/main/java/multipacks/postprocess/basic/MovePass.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/basic/MovePass.java
@@ -13,23 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package multipacks.postprocess;
+package multipacks.postprocess.basic;
 
 import java.io.IOException;
 
 import com.google.gson.JsonObject;
 
 import multipacks.bundling.BundleResult;
+import multipacks.postprocess.PostProcessPass;
 import multipacks.utils.Selects;
 import multipacks.utils.logging.AbstractMPLogger;
 import multipacks.vfs.Path;
 import multipacks.vfs.VirtualFs;
 
-public class CopyPass extends PostProcessPass {
+public class MovePass extends PostProcessPass {
 	private Path from;
 	private Path to;
 
-	public CopyPass(JsonObject config) {
+	public MovePass(JsonObject config) {
 		from = new Path(Selects.nonNull(config.get("from"), "'from' is empty").getAsString());
 		to = new Path(Selects.nonNull(config.get("to"), "'to' is empty").getAsString());
 	}
@@ -41,6 +42,7 @@ public class CopyPass extends PostProcessPass {
 			Path pTo = Path.join(to, new Path(tail));
 			byte[] bs = fs.read(pFrom);
 			fs.write(pTo, bs);
+			fs.delete(pFrom);
 		}
 	}
 }

--- a/multipacks-engine/src/main/java/multipacks/postprocess/font/FontIconsPass.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/font/FontIconsPass.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package multipacks.postprocess.font;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import multipacks.bundling.BundleResult;
+import multipacks.postprocess.PostProcessPass;
+import multipacks.postprocess.ProcessFailException;
+import multipacks.utils.ResourcePath;
+import multipacks.utils.Selects;
+import multipacks.utils.logging.AbstractMPLogger;
+import multipacks.vfs.Path;
+import multipacks.vfs.VirtualFs;
+
+public class FontIconsPass extends PostProcessPass {
+	private Path from;
+	private Path to;
+	private Path textures;
+	private GlyphMapping[] mapping;
+
+	private int currentChar = 0;
+
+	public FontIconsPass(JsonObject config) {
+		from = new Path(Selects.nonNull(config.get("from"), "'from' is empty").getAsString());
+		to = new Path(Selects.nonNull(config.get("to"), "'to' is empty").getAsString());
+		textures = new Path(Selects.nonNull(config.get("textures"), "'textures' is empty").getAsString());
+
+		JsonArray arr = Selects.nonNull(config.get("mapping"), "'mapping' is empty").getAsJsonArray();
+		mapping = new GlyphMapping[arr.size()];
+		for (int i = 0; i < mapping.length; i++) mapping[i] = new GlyphMapping(arr.get(i));
+	}
+
+	private int nextChar() {
+		for (GlyphMapping m : mapping) {
+			if (currentChar >= m.size()) {
+				currentChar -= m.size();
+				continue;
+			}
+
+			return m.get(currentChar++);
+		}
+		return -1;
+	}
+
+	@Override
+	public void apply(VirtualFs fs, BundleResult result, AbstractMPLogger logger) throws IOException {
+		JsonArray providers = new JsonArray();
+		GlyphsMap glyphs = result.getOrCreate(GlyphsMap.class, GlyphsMap::new);
+		ResourcePath fontId = to.toNamespacedKey(3).noFileExtension();
+
+		for (Path p : fs.ls(from)) {
+			if (!p.toString().endsWith(".json")) continue;
+			JsonObject json = fs.readJson(p).getAsJsonObject();
+
+			ResourcePath glyphId = new ResourcePath(Selects.getChain(json.get("id"), j -> j.getAsString(), "multipacks-unnamed:" + hashOf(p.toString())));
+			Path texture = p.parent().join(Selects.nonNull(json.get("texture"), "'texture' is missing in " + p).getAsString());
+			int ascent = Selects.nonNull(json.get("ascent"), "'ascent' is missing in " + p).getAsInt();
+			int height = Selects.nonNull(json.get("height"), "'height' is missing in " + p).getAsInt();
+
+			Path textureOutput = textures.join(glyphId.toString().replaceAll(":", "_") + ".png");
+			int charInt = nextChar();
+			if (charInt == -1) throw new ProcessFailException("Not enough mapped characters to process font icons glyphs");
+			char ch = (char) charInt;
+
+			JsonObject prov = new JsonObject();
+			prov.addProperty("type", "bitmap");
+			prov.addProperty("file", textureOutput.toNamespacedKey(3).toString());
+			prov.addProperty("ascent", ascent);
+			prov.addProperty("height", height);
+
+			JsonArray chars = new JsonArray();
+			chars.add(ch);
+			prov.add("chars", chars);
+
+			providers.add(prov);
+			fs.write(textureOutput, fs.read(texture));
+			glyphs.put(glyphId, new Glyph(fontId, glyphId, ch, ascent, height));
+		}
+
+		JsonObject obj = new JsonObject();
+		obj.add("providers", providers);
+		fs.writeJson(to, obj);
+		fs.delete(from);
+	}
+
+	private static char[] HEX = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
+	private static String hashOf(String text) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			digest.update(text.getBytes(StandardCharsets.UTF_8));
+			byte[] bs = digest.digest();
+			char[] cs = new char[bs.length * 2];
+			for (int i = 0; i < bs.length; i++) {
+				cs[i * 2 + 0] = HEX[(Byte.toUnsignedInt(bs[i]) & 0xF0) >> 4];
+				cs[i * 2 + 1] = HEX[(Byte.toUnsignedInt(bs[i]) & 0x0F) >> 0];
+			}
+			return String.valueOf(cs);
+		} catch (NoSuchAlgorithmException e) {
+			e.printStackTrace();
+			return (Math.random() + "").replace('.', '-');
+		}
+	}
+}

--- a/multipacks-engine/src/main/java/multipacks/postprocess/font/Glyph.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/font/Glyph.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package multipacks.postprocess.font;
+
+import multipacks.utils.ResourcePath;
+
+public class Glyph {
+	public final ResourcePath fontId, glyphId;
+	public final char character;
+	public final int ascent, height;
+
+	public Glyph(ResourcePath fontId, ResourcePath glyphId, char character, int ascent, int height) {
+		this.fontId = fontId;
+		this.glyphId = glyphId;
+		this.character = character;
+		this.ascent = ascent;
+		this.height = height;
+	}
+
+	@Override
+	public String toString() {
+		return "Glyph(" + fontId + "/" + glyphId + " => " + Integer.toUnsignedString(character, 16) + ")";
+	}
+}

--- a/multipacks-engine/src/main/java/multipacks/postprocess/font/GlyphMapping.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/font/GlyphMapping.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package multipacks.postprocess.font;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSyntaxException;
+
+import multipacks.utils.Selects;
+
+public class GlyphMapping {
+	public final char from;
+	public final char to;
+
+	public GlyphMapping(char from, char to) {
+		this.from = from;
+		this.to = to;
+	}
+
+	public GlyphMapping(JsonElement json) {
+		if (json.isJsonPrimitive()) from = to = json.getAsCharacter();
+		else if (json.isJsonObject()) {
+			from = Selects.nonNull(json.getAsJsonObject().get("from"), "'from' is empty").getAsCharacter();
+			to = Selects.nonNull(json.getAsJsonObject().get("to"), "'to' is empty").getAsCharacter();
+		} else if (json.isJsonArray()) {
+			JsonArray arr = json.getAsJsonArray();
+			char a = arr.get(0).getAsCharacter();
+			char b = arr.get(1).getAsCharacter();
+			from = a > b? b : a;
+			to = a > b? a : b;
+		} else throw new JsonSyntaxException("Cannot convert " + json + " to characters mapping for glyphs");
+	}
+
+	public int size() { return to - from + 1; }
+	public int get(int ptr) { return ptr < size()? from + ptr : -1; }
+}

--- a/multipacks-engine/src/main/java/multipacks/postprocess/font/GlyphsMap.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/font/GlyphsMap.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package multipacks.postprocess.font;
+
+import java.util.HashMap;
+
+import multipacks.utils.ResourcePath;
+
+public class GlyphsMap extends HashMap<ResourcePath, Glyph> {
+	private static final long serialVersionUID = -2281029873160010532L;
+}

--- a/multipacks-engine/src/main/java/multipacks/postprocess/overlays/Overlay.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/overlays/Overlay.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package multipacks.postprocess.overlays;
 
 import java.awt.image.BufferedImage;

--- a/multipacks-engine/src/main/java/multipacks/postprocess/overlays/Overlay.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/overlays/Overlay.java
@@ -1,0 +1,34 @@
+package multipacks.postprocess.overlays;
+
+import java.awt.image.BufferedImage;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+
+import multipacks.utils.Selects;
+import multipacks.vfs.Path;
+
+public class Overlay {
+	public final Path overlayFile;
+	public final int x, y;
+	public BufferedImage cachedImage;
+
+	public Overlay(Path overlayFile, int x, int y) {
+		this.overlayFile = overlayFile;
+		this.x = x;
+		this.y = y;
+	}
+
+	public Overlay(JsonElement json) {
+		if (json.isJsonPrimitive()) {
+			overlayFile = new Path(json.getAsString());
+			x = 0; y = 0;
+		} else if (json.isJsonObject()) {
+			JsonObject obj = json.getAsJsonObject();
+			overlayFile = new Path(Selects.nonNull(obj.get("path"), "'path' is empty").getAsString());
+			x = Selects.nonNull(obj.get("x"), "'x' is empty").getAsInt();
+			y = Selects.nonNull(obj.get("y"), "'y' is empty").getAsInt();
+		} else throw new JsonSyntaxException("Invalid JSON object type: " + json.getClass().getName());
+	}
+}

--- a/multipacks-engine/src/main/java/multipacks/postprocess/overlays/OverlayPass.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/overlays/OverlayPass.java
@@ -1,0 +1,62 @@
+package multipacks.postprocess.overlays;
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.imageio.ImageIO;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import multipacks.bundling.BundleResult;
+import multipacks.postprocess.PostProcessPass;
+import multipacks.utils.Selects;
+import multipacks.utils.logging.AbstractMPLogger;
+import multipacks.vfs.Path;
+import multipacks.vfs.VirtualFs;
+
+public class OverlayPass extends PostProcessPass {
+	private Path target;
+	private Overlay[] overlays;
+
+	public OverlayPass(JsonObject config) {
+		target = new Path(Selects.nonNull(config.get("target"), "'target' is empty").getAsString());
+		JsonArray arr = Selects.nonNull(config.get("overlays"), "'overlays' is empty").getAsJsonArray();
+		overlays = new Overlay[arr.size()];
+		for (int i = 0; i < overlays.length; i++) overlays[i] = new Overlay(arr.get(i));
+	}
+
+	@Override
+	public void apply(VirtualFs fs, BundleResult result, AbstractMPLogger logger) throws IOException {
+		for (Overlay overlay : overlays) {
+			InputStream in = fs.getStream(overlay.overlayFile);
+			if (in == null) {
+				logger.warning("Overlay " + overlay.overlayFile + " doesn't exists, skipping...");
+				continue;
+			}
+
+			overlay.cachedImage = ImageIO.read(in);
+			in.close();
+		}
+
+		for (Path targetFile : fs.ls(target)) {
+			InputStream in = fs.getStream(targetFile);
+			BufferedImage imgTarget = ImageIO.read(in);
+			in.close();
+
+			BufferedImage imgOut = new BufferedImage(imgTarget.getWidth(), imgTarget.getHeight(), BufferedImage.TYPE_4BYTE_ABGR);
+			Graphics2D g = imgOut.createGraphics();
+			g.drawImage(imgTarget, null, 0, 0);
+
+			for (Overlay overlay : overlays) if (overlay.cachedImage != null) g.drawImage(overlay.cachedImage, null, overlay.x, overlay.y);
+
+			ByteArrayOutputStream out = new ByteArrayOutputStream();
+			ImageIO.write(imgOut, "PNG", out);
+			fs.write(targetFile, out.toByteArray());
+			System.out.println(targetFile);
+		}
+	}
+}

--- a/multipacks-engine/src/main/java/multipacks/postprocess/overlays/OverlayPass.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/overlays/OverlayPass.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package multipacks.postprocess.overlays;
 
 import java.awt.Graphics2D;

--- a/multipacks-engine/src/main/java/multipacks/utils/ResourcePath.java
+++ b/multipacks-engine/src/main/java/multipacks/utils/ResourcePath.java
@@ -17,6 +17,8 @@ package multipacks.utils;
 
 import java.util.Objects;
 
+import multipacks.vfs.Path;
+
 public class ResourcePath {
 	public final String namespace;
 	public final String path;
@@ -35,6 +37,13 @@ public class ResourcePath {
 			namespace = "minecraft";
 			path = str;
 		}
+	}
+
+	public ResourcePath noFileExtension() {
+		Path p = new Path(path);
+		String[] splits = p.fileName().split("\\.");
+		if (splits.length == 1) return this;
+		return new ResourcePath(namespace, path.substring(0, path.length() - splits[splits.length - 1].length() - 1));
 	}
 
 	@Override

--- a/multipacks-engine/src/main/java/multipacks/vfs/VirtualFs.java
+++ b/multipacks-engine/src/main/java/multipacks/vfs/VirtualFs.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 
@@ -110,7 +111,7 @@ public class VirtualFs {
 	}
 
 	public void writeText(Path file, String text) { write(file, text.getBytes(StandardCharsets.UTF_8)); }
-	public void writeJson(Path file, JsonElement json) { writeText(file, json.toString()); }
+	public void writeJson(Path file, JsonElement json) { writeText(file, new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create().toJson(json)); }
 
 	/**
 	 * List all paths from both virtual file system and underlying file system (if the path is not marked as deleted).


### PR DESCRIPTION
This simply added back post processing passes before rework. Some passes have been renamed to reflect its actual usage:
- ``remap`` becomes ``move``
- ``clone`` becomes ``copy``
- ``multi-sprites`` becomes ``atlas``

``font-icons`` pass schema have been changed:
```json
{
  "type": "font-icons",
  "from": "assets/namespace/whatever_this_is",
  "to": "assets/namespace/font/font_id.json",
  "mapping": [
    ["from_code", "to_code"],
    {"from": "from_code", "to": "to_code"}
  ],
  "textures": "assets/namespace/textures/font/whatever_this_is"
}
```