### PR TITLE
Build script changes for better support with other projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,10 @@ allprojects {
     project(":$it") {
         apply plugin: "maven-publish"
 
+        java {
+            withSourcesJar()
+        }
+
         publishing {
             publications {
                 mavenJava(MavenPublication) {

--- a/multipacks-engine/build.gradle
+++ b/multipacks-engine/build.gradle
@@ -4,7 +4,7 @@ repositories {
 
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.2'
-    implementation 'com.google.code.gson:gson:2.7'
+    api 'com.google.code.gson:gson:2.7'
 }
 
 tasks.named('test') {

--- a/multipacks-sample-plugin/build.gradle
+++ b/multipacks-sample-plugin/build.gradle
@@ -1,3 +1,7 @@
+repositories {
+    mavenCentral()
+}
+
 dependencies {
     implementation project(':multipacks-engine')
 }

--- a/multipacks-spigot/build.gradle
+++ b/multipacks-spigot/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation project(':multipacks-engine')
+    api project(':multipacks-engine')
     compileOnly 'org.spigotmc:spigot-api:1.18.2-R0.1-SNAPSHOT'
 
     shadow project(':multipacks-engine')


### PR DESCRIPTION
Currently Gson in engine subproject and Multipacks Engine in Spigot subproject is being included as ``implementation``. This PR changes it to ``api``, which will displays on consumers' compile classpath.

This PR also resolves the missing sources issue with published Maven artifacts.