### PR TITLE
Fix Multipacks plugins system throwing NoClassDefFoundError

### DIFF
--- a/multipacks-cli/src/main/java/multipacks/cli/Main.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/Main.java
@@ -16,6 +16,8 @@
 package multipacks.cli;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -29,7 +31,7 @@ import multipacks.plugins.MultipacksPlugin;
 import multipacks.versioning.Version;
 
 public class Main {
-	public static void main(String[] args) {
+	public static void main(String[] args) throws IOException {
 		Platform currentPlatform = Platform.getPlatform();
 
 		if (currentPlatform == Platform.UNKNOWN) {
@@ -166,5 +168,8 @@ public class Main {
 		}
 
 		cli.exec(regularArguments.toArray(String[]::new));
+
+		// Clean up
+		for (URLClassLoader loader : MultipacksPlugin.JAR_HANDLES) loader.close();
 	}
 }

--- a/multipacks-spigot/src/main/java/multipacks/spigot/MultipacksSpigot.java
+++ b/multipacks-spigot/src/main/java/multipacks/spigot/MultipacksSpigot.java
@@ -17,6 +17,7 @@ package multipacks.spigot;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URLClassLoader;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -130,6 +131,16 @@ public class MultipacksSpigot extends JavaPlugin {
 		repos = null;
 		config = null;
 		logger = null;
+
+		// Resources releasing
+		for (URLClassLoader loader : MultipacksPlugin.JAR_HANDLES) {
+			try {
+				loader.close();
+			} catch (IOException e) {
+				e.printStackTrace();
+				logger.error("Cannot close " + loader.getName() + " class loader. Expect some memory leaks when using /reload");
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
Some plugins may load additional class when requested. This PR will move the ``close()`` part for class loaders after CLI is finished or server is stopped (hopefully no memory leaks with happens).