### PR TITLE
Prevent Gson from being shadowed to Spigot plugin jar

### DIFF
--- a/multipacks-spigot/build.gradle
+++ b/multipacks-spigot/build.gradle
@@ -29,5 +29,7 @@ processResources {
 }
 
 shadowJar {
-     relocate 'com.google.gson', 'multipacks.generated.relocated.gson'
+    dependencies {
+        include(project(':multipacks-engine'))
+    }
 }


### PR DESCRIPTION
Previously, Multipacks shadows ``com.google.gson`` to the final Spigot plugin jar, which causes ``ClassCastException``. This PR prevent that dependency from shadowing by simply using ``include(project(':multipacks-engine'))`` in buildscript.