### PR TITLE
Multipacks for Spigot improvement

### DIFF
--- a/multipacks-engine/src/main/java/multipacks/plugins/MultipacksDefaultPlugin.java
+++ b/multipacks-engine/src/main/java/multipacks/plugins/MultipacksDefaultPlugin.java
@@ -35,7 +35,7 @@ import multipacks.postprocess.overlays.OverlayPass;
 public class MultipacksDefaultPlugin implements MultipacksPlugin {
 	@Override
 	public PacksRepository parseRepository(File root, String uri) {
-		if (uri.startsWith("file:")) return new LocalRepository(new File(uri.substring(5)));
+		if (uri.startsWith("file:")) return new LocalRepository(new File(root, uri.substring(5)));
 		return null;
 	}
 

--- a/multipacks-engine/src/main/java/multipacks/utils/PlatformAPI.java
+++ b/multipacks-engine/src/main/java/multipacks/utils/PlatformAPI.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package multipacks.utils;
 
 import static java.lang.annotation.ElementType.TYPE;

--- a/multipacks-engine/src/main/java/multipacks/utils/PlatformAPI.java
+++ b/multipacks-engine/src/main/java/multipacks/utils/PlatformAPI.java
@@ -1,0 +1,19 @@
+package multipacks.utils;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Mark the API as platform-specific. When using API that is related to platform-specific, you have to be careful
+ * at suppling inputs to the method or constructor. 
+ * @author nahkd
+ *
+ */
+@Retention(SOURCE)
+@Target({ TYPE, METHOD })
+public @interface PlatformAPI {
+}

--- a/multipacks-spigot/src/main/java/multipacks/spigot/MultipacksSpigot.java
+++ b/multipacks-spigot/src/main/java/multipacks/spigot/MultipacksSpigot.java
@@ -16,13 +16,16 @@
 package multipacks.spigot;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URLClassLoader;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
@@ -33,11 +36,15 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 import multipacks.bundling.BundleIgnore;
+import multipacks.bundling.BundleInclude;
+import multipacks.bundling.BundleResult;
 import multipacks.bundling.PackBundler;
 import multipacks.management.PacksRepository;
+import multipacks.packs.Pack;
 import multipacks.plugins.MultipacksDefaultPlugin;
 import multipacks.plugins.MultipacksPlugin;
 import multipacks.utils.IOUtils;
+import multipacks.utils.PlatformAPI;
 import multipacks.utils.ResourcePath;
 import multipacks.utils.Selects;
 
@@ -46,20 +53,37 @@ import multipacks.utils.Selects;
  * objects and Spigot/Bukkit objects, as well as packs generation.
  * @author nahkd
  * @see #getInstance()
+ * @see #getBuildOutput()
  * @apiNote While using Multipacks Spigot, please do not touch any method related to Multipacks dynamic plugins
  * APIs (those are {@link MultipacksPlugin#loadJarPlugin(File)} and {@link MultipacksPlugin#loadJarPlugin(java.net.URL)}).
  * Some users may use /reload (not recommended, but who cares?) or "plugins management" plugin to controls how server
  * plugins works. Using any of these methods will causes memory leak. The only exception is
- * {@link MultipacksPlugin#loadPlugin(MultipacksPlugin)}, which loads the plugin instance.
+ * {@link MultipacksPlugin#loadPlugin(MultipacksPlugin)}, which loads the plugin instance.<br>
+ * 
+ * It is also important to always load Multipacks plugin on {@link Plugin#onLoad()} method, or your post processing
+ * passes will not works.
  *
  */
+@PlatformAPI
 public class MultipacksSpigot extends JavaPlugin {
 	private JavaMPLogger logger;
 	private JsonObject config;
 	private List<PacksRepository> repos;
 	private PacksRepository selectedRepo;
 
+	private Pack masterPack;
+	private File packArtifact;
+	private BundleResult packOutput;
+
+	// Callbacks
+	private HashSet<Consumer<BundleResult>> onMasterRebuild = new HashSet<>();
+
 	private static MultipacksSpigot INSTANCE;
+
+	@Override
+	public void onLoad() {
+		MultipacksPlugin.loadPlugin(new MultipacksDefaultPlugin());
+	}
 
 	@Override
 	public void onEnable() {
@@ -67,7 +91,22 @@ public class MultipacksSpigot extends JavaPlugin {
 		long benchmarkStart = System.nanoTime();
 
 		logger = new JavaMPLogger(getLogger());
-		MultipacksPlugin.loadPlugin(new MultipacksDefaultPlugin());
+		reloadJsonConfig(true);
+		logger.info("Plugin enabled in " + new DecimalFormat("#0.000").format(((System.nanoTime() - benchmarkStart) / 1000000.0)) + "ms");
+	}
+
+	/**
+	 * Reload plugin configurations.
+	 */
+	public void reloadJsonConfig(boolean enablingPlugin) {
+		// Reset all
+		config = null;
+		repos = null;
+		selectedRepo = null;
+
+		masterPack = null;
+		packArtifact = null;
+		packOutput = null;
 
 		File configFile = new File(getDataFolder(), "config.json");
 
@@ -75,14 +114,19 @@ public class MultipacksSpigot extends JavaPlugin {
 			logger.warning("config.json doesn't exists, copying from .jar...");
 			saveResource("config.json", false);
 
-			logger.info("");
-			logger.info("  Welcome to Multipacks API for Spigot!");
-			logger.info("  You are using server version " + getServer().getVersion());
-			logger.info("");
-			logger.info("  This plugin only contains some basic APIs for other plugins");
-			logger.info("  to depends on. This plugin doesn't have ability to send Multipacks");
-			logger.info("  pack to client, so you might need additional plugin to do this.");
-			logger.info("");
+			if (enablingPlugin) {
+				logger.info("");
+				logger.info("  Welcome to Multipacks API for Spigot!");
+				logger.info("  You are using server version " + getServer().getVersion());
+				logger.info("");
+				logger.info("  This plugin only contains some basic APIs for other plugins");
+				logger.info("  to depends on. This plugin doesn't have ability to send Multipacks");
+				logger.info("  pack to client, so you might need additional plugin to do this.");
+				logger.info("");
+			} else {
+				logger.warning("config.json appears to be deleted after using /mp reload");
+				logger.warning("If this is intentional, you can ignore this message");
+			}
 		}
 
 		try {
@@ -90,6 +134,7 @@ public class MultipacksSpigot extends JavaPlugin {
 		} catch (IOException e) {
 			e.printStackTrace();
 			logger.error("Failed to get configuration from config.json! (Permission error?)");
+			return;
 		}
 
 		JsonArray repositoriesJson = Selects.getChain(config.get("repositories"), v -> v.getAsJsonArray(), null);
@@ -106,23 +151,63 @@ public class MultipacksSpigot extends JavaPlugin {
 
 		for (String s : repositoriesStr) {
 			PacksRepository repo = PacksRepository.parseRepository(getDataFolder(), s);
-
 			if (repo == null) {
 				logger.warning("Unknown repository: " + s);
 				continue;
 			}
-
 			repos.add(repo);
 		}
-
 		logger.info(repos.size() + " repositories found in configuration file");
 
 		int selectedRepoIndex = Selects.getChain(config.get("selectedRepo"), v -> v.getAsInt(), 0);
-
 		if (selectedRepoIndex >= repos.size()) logger.info("Invalid repository #" + selectedRepoIndex + ", selecting no repository...");
 		else selectedRepo = repos.get(selectedRepoIndex);
 
-		logger.info("Plugin enabled in " + new DecimalFormat("#0.000").format(((System.nanoTime() - benchmarkStart) / 1e6)) + "ms");
+		if (config.has("pack")) {
+			JsonObject packConfig = config.get("pack").getAsJsonObject();
+			if (packConfig.has("enabled") && packConfig.get("enabled").getAsBoolean()) try {
+				logger.info("Master pack bundling is enabled");
+				String path = Selects.getChain(packConfig.get("folder"), j -> j.getAsString(), "master-pack");
+				File masterPackDir = new File(getDataFolder(), path.replace('/', File.separatorChar));
+
+				String result = Selects.getChain(packConfig.get("result"), j -> j.getAsString(), "master-pack.zip");
+				File masterPackResult = new File(getDataFolder(), result.replace('/', File.separatorChar));
+
+				if (masterPackDir.exists()) {
+					masterPack = new Pack(masterPackDir);
+					packArtifact = masterPackResult;
+					rebuildMasterPack();
+				} else {
+					logger.error("Cannot open " + masterPackDir + ": Doesn't exists");
+				}
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+
+	/**
+	 * Rebuild master pack. Most of the time this action is performed manually using command.
+	 */
+	public boolean rebuildMasterPack() throws IOException {
+		packOutput = null;
+
+		if (masterPack == null) {
+			logger.warning("Cannot rebuild master pack: Pack is not defined in configuration.");
+			logger.warning("(reload configuration if you just recently enabled it)");
+			return false;
+		}
+
+		logger.info("Building master pack...");
+		PackBundler bundler = newBundler(getAvailableRepositories(), false);
+		if (!new File(packArtifact, "..").exists()) new File(packArtifact, "..").mkdirs();
+
+		try (FileOutputStream out = new FileOutputStream(packArtifact)) {
+			packOutput = bundler.bundle(masterPack, out, new BundleInclude[] { BundleInclude.RESOURCES });
+			for (Consumer<BundleResult> c : onMasterRebuild) c.accept(packOutput);
+			logger.info("Master pack built!");
+			return true;
+		}
 	}
 
 	@Override
@@ -141,22 +226,20 @@ public class MultipacksSpigot extends JavaPlugin {
 				logger.error("Cannot close " + loader.getName() + " class loader. Expect some memory leaks when using /reload");
 			}
 		}
+
+		onMasterRebuild.clear();
 	}
 
 	/**
 	 * Get currently selected repository.
 	 */
-	public PacksRepository getSelectedRepository() {
-		return selectedRepo;
-	}
+	public PacksRepository getSelectedRepository() { return selectedRepo; }
 
 	/**
 	 * Get a list of repositories that's available. This list is modifiable: you can add your
 	 * own repository if you want (think of paid repository access for example).
 	 */
-	public List<PacksRepository> getAvailableRepositories() {
-		return repos;
-	}
+	public List<PacksRepository> getAvailableRepositories() { return repos; }
 
 	/**
 	 * Create new bundler, which can be used to bundle resources and data packs.
@@ -176,7 +259,31 @@ public class MultipacksSpigot extends JavaPlugin {
 	}
 
 	/**
-	 * Get instance of this plugin.
+	 * Obtain the master pack build output. Quite useful for plugins that want to use Multipacks where player can mix
+	 * a bunch of packs together. Returns null if master pack is disabled.
+	 */
+	public BundleResult getBuildOutput() { return packOutput; }
+
+	/**
+	 * Obtain the master pack artifact location. This is the location that you'll have to serve it to players. Returns
+	 * null if master pack is disabled.
+	 */
+	public File getBuildArtifactLocation() { return packArtifact; }
+
+	/**
+	 * Register callback and call it when the master pack is built.
+	 * @return true if the callback is registered.
+	 */
+	public boolean registerMasterPackBuildCallback(Consumer<BundleResult> callback) { return onMasterRebuild.add(callback); }
+
+	/**
+	 * Unregister callback, prevent it from being called when the master pack is built.
+	 * @return true if the callback is unregistered.
+	 */
+	public boolean unregisterMasterPackBuildCallback(Consumer<BundleResult> callback) { return onMasterRebuild.remove(callback); }
+
+	/**
+	 * Get instance of this plugin. This is the main entry point for accessing most of Multipacks features on Spigot.
 	 */
 	public static MultipacksSpigot getInstance() {
 		return INSTANCE;

--- a/multipacks-spigot/src/main/java/multipacks/spigot/MultipacksSpigot.java
+++ b/multipacks-spigot/src/main/java/multipacks/spigot/MultipacksSpigot.java
@@ -45,6 +45,7 @@ import multipacks.management.PacksRepository;
 import multipacks.packs.Pack;
 import multipacks.plugins.MultipacksDefaultPlugin;
 import multipacks.plugins.MultipacksPlugin;
+import multipacks.spigot.commands.MainCommand;
 import multipacks.spigot.serving.LocalPackServer;
 import multipacks.spigot.serving.PackServer;
 import multipacks.utils.IOUtils;
@@ -99,6 +100,8 @@ public class MultipacksSpigot extends JavaPlugin {
 
 		logger = new JavaMPLogger(getLogger());
 		reloadJsonConfig(true);
+
+		getCommand("multipacks").setExecutor(new MainCommand(this));
 		logger.info("Plugin enabled in " + new DecimalFormat("#0.000").format(((System.nanoTime() - benchmarkStart) / 1000000.0)) + "ms");
 	}
 

--- a/multipacks-spigot/src/main/java/multipacks/spigot/MultipacksSpigot.java
+++ b/multipacks-spigot/src/main/java/multipacks/spigot/MultipacksSpigot.java
@@ -232,16 +232,23 @@ public class MultipacksSpigot extends JavaPlugin {
 
 			// Optionally serving the pack
 			if (packServer != null) for (Player p : getServer().getOnlinePlayers()) {
-				try {
-					packServer.serve(p, packArtifact);
-				} catch (Exception e) {
-					e.printStackTrace();
-					logger.warning("Cannot serve master pack to " + p.getName() + " (UUID = " + p.getUniqueId() + ")");
-				}
+				supplyMasterPack(p);
 			}
 
 			return true;
 		}
+	}
+
+	/**
+	 * Ask the packs server to supply the pack to target player. Does not return anything.
+	 */
+	public void supplyMasterPack(Player p) {
+		packServer.serve(p, packArtifact).whenComplete((result, e) -> {
+			if (e != null) {
+				e.printStackTrace();
+				logger.warning("Cannot serve master pack to " + p.getName() + " (UUID = " + p.getUniqueId() + ")");
+			}
+		});
 	}
 
 	@Override

--- a/multipacks-spigot/src/main/java/multipacks/spigot/commands/MainCommand.java
+++ b/multipacks-spigot/src/main/java/multipacks/spigot/commands/MainCommand.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package multipacks.spigot.commands;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+
+import multipacks.management.PacksRepository;
+import multipacks.management.PacksUploadable;
+import multipacks.packs.Pack;
+import multipacks.plugins.MultipacksPlugin;
+import multipacks.spigot.MultipacksSpigot;
+import multipacks.utils.Selects;
+
+public class MainCommand implements TabCompleter, CommandExecutor {
+	private static final String RELOAD = "multipacks.admin.reload";
+	private static final String REBUILD = "multipacks.admin.rebuild";
+	private static final String INSTALL = "multipacks.admin.install";
+
+	private MultipacksSpigot plugin;
+
+	public MainCommand(MultipacksSpigot plugin) {
+		this.plugin = plugin;
+	}
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+		if (args.length == 0) {
+			print(sender, "&cMultipacks &7by &fMangoPlex");
+			print(sender, "&7(&f" + plugin.getAvailableRepositories().size() + " &7repositories, &f" + MultipacksPlugin.PLUGINS.size() + " &7plugins)");
+			printCommand(sender, RELOAD, label + " reload", "Reload Multipacks Spigot configuration");
+			printCommand(sender, REBUILD, label + " rebuild", "Rebuild master pack (must be enabled in config)");
+			printCommand(sender, INSTALL, label + " install &epath/to/packdir", "Install pack to selected repository");
+			return true;
+		}
+		if (args[0].equalsIgnoreCase("reload") && sender.hasPermission(RELOAD)) {
+			print(sender, "&7Reloading Multipacks...");
+			plugin.reloadJsonConfig(false);
+			return print(sender, "&7Reloaded!");
+		}
+		if (args[0].equalsIgnoreCase("rebuild") && sender.hasPermission(REBUILD)) {
+			print(sender, "&7Rebuilding master pack...");
+			boolean success;
+			try {
+				success = plugin.rebuildMasterPack();
+			} catch (Exception e) {
+				e.printStackTrace();
+				return print(sender, "&cCommand failed: &f" + Selects.firstNonNull(e.getMessage(), "Details printed in console"));
+			}
+
+			return print(sender, success? "&cRebuild failed: &fDetail messages printed in console" : "&7Rebuilt!");
+		}
+		if (args[0].equalsIgnoreCase("install") && sender.hasPermission(INSTALL)) {
+			if (args.length < 2) return print(sender, "&cCommand failed: &fMissing path to pack");
+			PacksRepository repo = plugin.getSelectedRepository();
+			if (repo == null) return print(sender, "&cCommand failed: &fNo repository selected");
+			if (!(repo instanceof PacksUploadable uploadable)) return print(sender, "&cCommand failed: &fSelected repository does not have uploading mechanism");
+
+			print(sender, "&7Installing...");
+			plugin.getLogger().info("Reading pack folder (relative to current working directory)...");
+			File packRoot = new File(args[1]);
+			if (!packRoot.exists() || packRoot.isDirectory()) {
+				plugin.getLogger().severe("Cannot install " + args[1] + ": Doesn't exists or not a directory");
+				return print(sender, "&cCommand failed: &f" + args[1] + " doesn't exists or not a folder");
+			}
+
+			boolean success;
+			try {
+				Pack pack = new Pack(packRoot);
+				success = uploadable.putPack(pack);
+			} catch (IllegalAccessException e) {
+				e.printStackTrace();
+				return print(sender, "&cCommand failed: &f" + Selects.firstNonNull(e.getMessage(), "Access is denied while installing"));
+			} catch (Exception e) {
+				e.printStackTrace();
+				return print(sender, "&cCommand failed: &f" + Selects.firstNonNull(e.getMessage(), "Details printed in console"));
+			}
+
+			return print(sender, success? "&7Pack installed! Use /" + label + " rebuild to rebuild pack" : "&cCommand failed: &fInstall failed");
+		}
+
+		return print(sender, "&cUnknown command: &f/" + label + " " + String.join(" ", args));
+	}
+
+	@Override
+	public List<String> onTabComplete(CommandSender sender, Command command, String label, String[] args) {
+		ArrayList<String> suggestions = new ArrayList<>();
+		String partial = args[args.length - 1];
+		if (args.length == 1) {
+			suggest(sender, RELOAD, "reload", suggestions);
+			suggest(sender, REBUILD, "rebuild", suggestions);
+			suggest(sender, INSTALL, "install", suggestions);
+			return suggestions.stream().filter(v -> v.startsWith(partial)).toList();
+		}
+
+		return suggestions;
+	}
+
+	private boolean print(CommandSender sender, String... message) {
+		for (String m : message) sender.sendMessage(ChatColor.translateAlternateColorCodes('&', m));
+		return true;
+	}
+
+	private boolean printCommand(CommandSender sender, String permission, String cmd, String description) {
+		if (!sender.hasPermission(permission)) return true;
+		return print(sender, "&7/&f" + cmd + " &8: &7" + description);
+	}
+
+	private void suggest(CommandSender sender, String permission, String cmd, List<String> suggestions) {
+		if (sender.hasPermission(permission)) suggestions.add(cmd);
+	}
+}

--- a/multipacks-spigot/src/main/java/multipacks/spigot/commands/MainCommand.java
+++ b/multipacks-spigot/src/main/java/multipacks/spigot/commands/MainCommand.java
@@ -68,7 +68,7 @@ public class MainCommand implements TabCompleter, CommandExecutor {
 				return print(sender, "&cCommand failed: &f" + Selects.firstNonNull(e.getMessage(), "Details printed in console"));
 			}
 
-			return print(sender, success? "&cRebuild failed: &fDetail messages printed in console" : "&7Rebuilt!");
+			return print(sender, success? "&7Master pack rebuilt!" : "&cRebuild failed: &fDetail messages printed in console");
 		}
 		if (args[0].equalsIgnoreCase("install") && sender.hasPermission(INSTALL)) {
 			if (args.length < 2) return print(sender, "&cCommand failed: &fMissing path to pack");
@@ -79,7 +79,7 @@ public class MainCommand implements TabCompleter, CommandExecutor {
 			print(sender, "&7Installing...");
 			plugin.getLogger().info("Reading pack folder (relative to current working directory)...");
 			File packRoot = new File(args[1]);
-			if (!packRoot.exists() || packRoot.isDirectory()) {
+			if (!packRoot.exists() || !packRoot.isDirectory()) {
 				plugin.getLogger().severe("Cannot install " + args[1] + ": Doesn't exists or not a directory");
 				return print(sender, "&cCommand failed: &f" + args[1] + " doesn't exists or not a folder");
 			}

--- a/multipacks-spigot/src/main/java/multipacks/spigot/serving/LocalPackServer.java
+++ b/multipacks-spigot/src/main/java/multipacks/spigot/serving/LocalPackServer.java
@@ -1,0 +1,70 @@
+package multipacks.spigot.serving;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.bukkit.entity.Player;
+
+import com.google.common.io.Files;
+import com.google.gson.JsonObject;
+
+import multipacks.utils.logging.AbstractMPLogger;
+
+public class LocalPackServer implements PackServer {
+	private static final String FILE_NAME = "multipacks-spigot-generated.zip";
+	private File resourcesFile;
+
+	public LocalPackServer(AbstractMPLogger logger, JsonObject config) {
+		String osName = System.getProperty("os.name", "Unix").toLowerCase();
+		Map<String, String> env = System.getenv();
+
+		// Windows
+		if (osName.startsWith("windows")) {
+			if (env.containsKey("APPDATA")) resourcesFile = new File(env.get("APPDATA") + "\\.minecraft\\resourcepacks");
+			else resourcesFile = new File(System.getProperty("user.home", "C:\\Users\\Public") + "\\AppData\\Roaming\\.minecraft\\resourcepacks");
+		}
+
+		// Unix-like
+		// We assume the game data directory is stored at homedir
+		else if (osName.contains("nix")) resourcesFile = new File(System.getProperty("user.home", "/.minecraft/resourcepacks"));
+
+		// What else?
+		else resourcesFile = null;
+
+		if (resourcesFile == null) {
+			logger.warning("Cannot identify platform: " + System.getProperty("os.name"));
+			logger.warning("If you are using Unix-like platform, please open a new issue at our GitHub repository");
+			resourcesFile = new File(FILE_NAME);
+		} else if (!resourcesFile.exists()) {
+			logger.warning("Missing " + resourcesFile + " folder!");
+			logger.warning("Local serving is only available for, well, locally hosted server. Please start this server in your local machine to continue.");
+			logger.warning("File will be deployed at current working directory.");
+			resourcesFile = new File(FILE_NAME);
+		} else resourcesFile = new File(resourcesFile, FILE_NAME);
+	}
+
+	@Override
+	public CompletableFuture<Boolean> serve(Player player, InputStream stream) {
+		try (FileOutputStream s = new FileOutputStream(resourcesFile)) {
+			stream.transferTo(s);
+			s.flush();
+			s.close();
+			return CompletableFuture.completedFuture(true);
+		} catch (Exception e) {
+			return CompletableFuture.failedFuture(e);
+		}
+	}
+
+	@Override
+	public CompletableFuture<Boolean> serve(Player player, File artifact) {
+		try {
+			Files.copy(artifact, resourcesFile);
+			return CompletableFuture.completedFuture(true);
+		} catch (Exception e) {
+			return CompletableFuture.failedFuture(e);
+		}
+	}
+}

--- a/multipacks-spigot/src/main/java/multipacks/spigot/serving/LocalPackServer.java
+++ b/multipacks-spigot/src/main/java/multipacks/spigot/serving/LocalPackServer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package multipacks.spigot.serving;
 
 import java.io.File;

--- a/multipacks-spigot/src/main/java/multipacks/spigot/serving/PackServer.java
+++ b/multipacks-spigot/src/main/java/multipacks/spigot/serving/PackServer.java
@@ -23,15 +23,20 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerJoinEvent;
 
 import com.google.gson.JsonObject;
 
+import multipacks.spigot.MultipacksSpigot;
 import multipacks.utils.PlatformAPI;
 import multipacks.utils.logging.AbstractMPLogger;
 
 /**
  * It's not the kind of HTTP or TCP server, but instead an interface for servers to serves the pack to
- * players. This server is responsible for taking the pack and force player to install it. 
+ * players. This server is responsible for taking the pack and force player to install it.<br>
+ * When the pack server is constructed, it should also register to {@link PlayerJoinEvent} to watch for players
+ * changes and supply them with built artifact (calls {@link MultipacksSpigot#supplyMasterPack(Player)} to
+ * supply).
  * @author nahkd
  *
  */

--- a/multipacks-spigot/src/main/java/multipacks/spigot/serving/PackServer.java
+++ b/multipacks-spigot/src/main/java/multipacks/spigot/serving/PackServer.java
@@ -17,13 +17,17 @@ package multipacks.spigot.serving;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
 
 import org.bukkit.entity.Player;
 
+import com.google.gson.JsonObject;
+
 import multipacks.utils.PlatformAPI;
+import multipacks.utils.logging.AbstractMPLogger;
 
 /**
  * It's not the kind of HTTP or TCP server, but instead an interface for servers to serves the pack to
@@ -36,26 +40,26 @@ public interface PackServer {
 	/**
 	 * Serve the bundled pack to player.
 	 * @param player Player that will be receiving the pack.
-	 * @param prompt Message that will be dusplayed on player's pack load request screen, or null to use
-	 * default prompt.
 	 * @param stream Bundled pack but as {@link InputStream}.
 	 * @return Async object: true if player accepted the pack and it is installed, false if they rejected
 	 * request.
 	 */
-	CompletableFuture<Boolean> serve(Player player, String prompt, InputStream stream) throws IOException;
+	CompletableFuture<Boolean> serve(Player player, InputStream stream);
 
 	/**
 	 * Serve the artifact as bundled pack to player. This method by default does not perform any caching.
 	 * @param player Player that will be receiving the pack.
-	 * @param prompt Message that will be displayed on player's pack load request screen, or null to use
-	 * default prompt.
 	 * @param artifact Built artifact location.
 	 * @return Async object: true if player accepted the pack and it is installed, false if they rejected
 	 * request.
 	 */
-	default CompletableFuture<Boolean> serve(Player player, String prompt, File artifact) throws IOException {
+	default CompletableFuture<Boolean> serve(Player player, File artifact) {
 		try (FileInputStream in = new FileInputStream(artifact)) {
-			return serve(player, prompt, in);
+			return serve(player, in);
+		} catch (Exception e) {
+			return CompletableFuture.failedFuture(e);
 		}
 	}
+
+	static HashMap<String, BiFunction<AbstractMPLogger, JsonObject, PackServer>> BUILDERS = new HashMap<>();
 }

--- a/multipacks-spigot/src/main/java/multipacks/spigot/serving/PackServer.java
+++ b/multipacks-spigot/src/main/java/multipacks/spigot/serving/PackServer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package multipacks.spigot.serving;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.CompletableFuture;
+
+import org.bukkit.entity.Player;
+
+import multipacks.utils.PlatformAPI;
+
+/**
+ * It's not the kind of HTTP or TCP server, but instead an interface for servers to serves the pack to
+ * players. This server is responsible for taking the pack and force player to install it. 
+ * @author nahkd
+ *
+ */
+@PlatformAPI
+public interface PackServer {
+	/**
+	 * Serve the bundled pack to player.
+	 * @param player Player that will be receiving the pack.
+	 * @param prompt Message that will be dusplayed on player's pack load request screen, or null to use
+	 * default prompt.
+	 * @param stream Bundled pack but as {@link InputStream}.
+	 * @return Async object: true if player accepted the pack and it is installed, false if they rejected
+	 * request.
+	 */
+	CompletableFuture<Boolean> serve(Player player, String prompt, InputStream stream) throws IOException;
+
+	/**
+	 * Serve the artifact as bundled pack to player. This method by default does not perform any caching.
+	 * @param player Player that will be receiving the pack.
+	 * @param prompt Message that will be displayed on player's pack load request screen, or null to use
+	 * default prompt.
+	 * @param artifact Built artifact location.
+	 * @return Async object: true if player accepted the pack and it is installed, false if they rejected
+	 * request.
+	 */
+	default CompletableFuture<Boolean> serve(Player player, String prompt, File artifact) throws IOException {
+		try (FileInputStream in = new FileInputStream(artifact)) {
+			return serve(player, prompt, in);
+		}
+	}
+}

--- a/multipacks-spigot/src/main/resources/config.json
+++ b/multipacks-spigot/src/main/resources/config.json
@@ -1,11 +1,15 @@
 {
+    "comment//0": "List of repositories that Multipacks will use. 'file:' always relatives to plugin data folder.",
     "repositories": [
         "file:packsRepository"
     ],
+
+    "comment//1": "The primary repository that plugins depending on Multipacks will use.",
     "selectedRepo": 0,
+
     "pack": {
-        "comment//0": "Master pack configuration. This is the one and only pack that all plugins will access.",
-        "comment//1": "Including other packs by editing multipacks.json inside your master pack",
+        "comment//0": "Master pack configuration. This is the one and only pack that all plugins will use.",
+        "comment//1": "Including other packs by editing multipacks.json inside your master pack.",
 
         "enabled": false,
         "folder": "my-pack",
@@ -16,6 +20,9 @@
             "comment//1": "Serving types can be installed by installing other Spigot plugins",
 
             "enabled": false,
+
+            "comment//2": "Local serving type will try copying multipacks-spigot-generated.zip to .minecraft/resourcepacks. Using",
+            "comment//3": "/mp rebuild will copy that file once again.",
             "servingType": "local"
         }
     }

--- a/multipacks-spigot/src/main/resources/config.json
+++ b/multipacks-spigot/src/main/resources/config.json
@@ -2,5 +2,21 @@
     "repositories": [
         "file:packsRepository"
     ],
-    "selectedRepo": 0
+    "selectedRepo": 0,
+    "pack": {
+        "comment//0": "Master pack configuration. This is the one and only pack that all plugins will access.",
+        "comment//1": "Including other packs by editing multipacks.json inside your master pack",
+
+        "enabled": false,
+        "folder": "my-pack",
+        "result": "my-pack-artifact.zip",
+
+        "serving": {
+            "comment//0": "This options is used for serving packs (Eg: over HTTP or copy to .minecraft/resourcespack)",
+            "comment//1": "Serving types can be installed by installing other Spigot plugins",
+
+            "enabled": false,
+            "servingType": "local"
+        }
+    }
 }

--- a/multipacks-spigot/src/main/resources/plugin.yml
+++ b/multipacks-spigot/src/main/resources/plugin.yml
@@ -3,3 +3,32 @@ author: MangoPlex
 version: ${version}
 main: multipacks.spigot.MultipacksSpigot
 api-version: 1.18
+
+commands:
+  multipacks:
+    description: Multipacks main command
+    usage: "/multipacks"
+    permission: multipacks.admin.command
+    permission-message: "Multipacks Spigot ${version} by MangoPlex"
+
+permissions:
+  multipacks.admin.*:
+    description: Allow all permissions
+    default: op
+    children:
+      multipacks.admin.command: true
+      multipacks.admin.reload: true
+      multipacks.admin.rebuild: true
+      multipacks.admin.install: true
+  multipacks.admin.command:
+    description: Allow player to use /multipacks
+    default: false
+  multipacks.admin.reload:
+    description: Allow player to reload Multipacks Spigot configuration
+    default: false
+  multipacks.admin.rebuild:
+    description: Allow player to rebuild master pack
+    default: false
+  multipacks.admin.install:
+    description: Allow player to install pack to repository
+    default: false


### PR DESCRIPTION
Mainly just a command and some extra APIs designed for Spigot plugin developers. Multipacks plugins loading will have to be loaded inside ``onLoad()`` method:

```java
@Override
public void onLoad() {
    MultipacksPlugin.loadPlugin(new MyMultipacksPlugin());
}
```

For regular users, you can now reload plugin configurations, along with the new master pack. Master pack is the one and only pack that you are going to distribute to players. Enabling this by adding ``pack`` field to configuration file:

```json
{
    "pack": {
        "//0": "Master pack configuration. This is the one and only pack that all plugins will use.",
        "//1": "Including other packs by editing multipacks.json inside your master pack.",

        "enabled": false,
        "folder": "my-pack",
        "result": "my-pack-artifact.zip",

        "serving": {
            "//0": "This options is used for serving packs (Eg: over HTTP or copy to .minecraft/resourcespack)",
            "//1": "Serving types can be installed by installing other Spigot plugins",

            "enabled": false,

            "//2": "Local serving type will try copying multipacks-spigot-generated.zip to .minecraft/resourcepacks. Using",
            "//3": "/mp rebuild will copy that file once again.",
            "servingType": "local"
        }
    }
}
```

``result`` file will be created inside plugin data directory.

This master pack is also shared to all plugins that uses Multipacks for Spigot.

Command and subcommands are also added to Spigot plugin; just use ``/multipacks`` to see all subcommands. Permissions for each subcommand:
```yml
permissions:
  multipacks.admin.*:
    description: Allow all permissions
    default: op
    children:
      multipacks.admin.command: true
      multipacks.admin.reload: true
      multipacks.admin.rebuild: true
      multipacks.admin.install: true
  multipacks.admin.command:
    description: Allow player to use /multipacks
    default: false
  multipacks.admin.reload:
    description: Allow player to reload Multipacks Spigot configuration
    default: false
  multipacks.admin.rebuild:
    description: Allow player to rebuild master pack
    default: false
  multipacks.admin.install:
    description: Allow player to install pack to repository
    default: false
```