### PR TITLE
Contents allocations API and Item models allocation

### DIFF
--- a/multipacks-engine/src/main/java/multipacks/plugins/MultipacksDefaultPlugin.java
+++ b/multipacks-engine/src/main/java/multipacks/plugins/MultipacksDefaultPlugin.java
@@ -24,6 +24,7 @@ import com.google.gson.JsonObject;
 import multipacks.management.LocalRepository;
 import multipacks.management.PacksRepository;
 import multipacks.postprocess.PostProcessPass;
+import multipacks.postprocess.allocations.modelsdata.CustomModelsPass;
 import multipacks.postprocess.atlas.AtlasPass;
 import multipacks.postprocess.basic.CopyPass;
 import multipacks.postprocess.basic.DeletePass;
@@ -49,5 +50,6 @@ public class MultipacksDefaultPlugin implements MultipacksPlugin {
 		reg.put("font-icons", FontIconsPass::new);
 		reg.put("atlas", AtlasPass::new);
 		reg.put("overlay", OverlayPass::new);
+		reg.put("custom-models", CustomModelsPass::new);
 	}
 }

--- a/multipacks-engine/src/main/java/multipacks/postprocess/allocations/Allocated.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/allocations/Allocated.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package multipacks.postprocess.allocations;
+
+/**
+ * Allocated object. This object is obtained from {@link Allocator}.
+ * @author nahkd
+ *
+ */
+public interface Allocated {
+}

--- a/multipacks-engine/src/main/java/multipacks/postprocess/allocations/AllocationSpace.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/allocations/AllocationSpace.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package multipacks.postprocess.allocations;
+
+import java.io.IOException;
+
+import multipacks.vfs.Path;
+import multipacks.vfs.VirtualFs;
+
+/**
+ * Allocation space.
+ * @author nahkd
+ *
+ * @param <T> Allocated object type.
+ * @param <D> Allocation data (Eg: {@link Path} to model file).
+ */
+public abstract class AllocationSpace<T extends Allocated, D> {
+	/**
+	 * Get the size of this allocation space.
+	 */
+	public abstract int size();
+
+	/**
+	 * Get the allocated object at specified index.
+	 * @param index Index value. This value is always less than the {@link #size()} of this allocation
+	 * space.
+	 * @param fs Virtual file system of the targeted pack, mainly used for processing allocation.
+	 * @param data Allocation data.
+	 * @return Allocated object at specified index.
+	 */
+	public abstract T allocate(int index, VirtualFs fs, D data) throws IOException;
+}

--- a/multipacks-engine/src/main/java/multipacks/postprocess/allocations/Allocator.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/allocations/Allocator.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package multipacks.postprocess.allocations;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import multipacks.bundling.BundleResult;
+import multipacks.vfs.Path;
+import multipacks.vfs.VirtualFs;
+
+/**
+ * Allocations allow different post processing passes to obtain the same content type without introducing
+ * conflicts. An example would be custom model data, where each item can have "CustomModelData" NBT value
+ * and we need to use that for, let's say... multi-parts custom entity for example. This will be used
+ * with {@link BundleResult#getOrCreate(Class, java.util.function.Supplier)}.
+ * @author nahkd
+ * 
+ * @param <T> Allocated object type.
+ * @param <D> Allocation data (Eg: {@link Path} to model file).
+ * 
+ */
+public abstract class Allocator<T extends Allocated, D> {
+	private int current = 0;
+	public final ArrayList<AllocationSpace<T, D>> spaces = new ArrayList<>();
+
+	/**
+	 * Add another allocation space on top of all spaces. Convenient method for {@link #spaces}
+	 * {@link ArrayList#add(Object)}
+	 * @param space
+	 */
+	public void add(AllocationSpace<T, D> space) {
+		this.spaces.add(space);
+	}
+
+	/**
+	 * Allocate a new object from pending allocation spaces.
+	 * @return An allocated object, or null if this allocator ran out of spaces. Recommended approach for
+	 * allocator ran out of spaces is to add another space to ensure there always enough space (space from
+	 * JSON object for example).
+	 * @see #add(AllocationSpace)
+	 */
+	public T allocateNew(VirtualFs fs, D data) throws IOException {
+		if (spaces.size() == 0) return null;
+		int p = current;
+		// TODO optimize me
+		for (AllocationSpace<T, D> space : spaces) {
+			if (p < space.size()) {
+				current++;
+				return space.allocate(p, fs, data);
+			}
+
+			p -= space.size();
+			continue;
+		}
+
+		return null;
+	}
+}

--- a/multipacks-engine/src/main/java/multipacks/postprocess/allocations/modelsdata/AllocatedModelData.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/allocations/modelsdata/AllocatedModelData.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package multipacks.postprocess.allocations.modelsdata;
+
+import multipacks.postprocess.allocations.Allocated;
+import multipacks.utils.ResourcePath;
+
+/**
+ * Allocated custom model data.
+ * @author nahkd
+ *
+ */
+public class AllocatedModelData implements Allocated {
+	public final ResourcePath itemId;
+	public final int modelId;
+
+	public AllocatedModelData(ResourcePath itemId, int modelId) {
+		this.itemId = itemId;
+		this.modelId = modelId;
+	}
+}

--- a/multipacks-engine/src/main/java/multipacks/postprocess/allocations/modelsdata/CustomModelsPass.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/allocations/modelsdata/CustomModelsPass.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package multipacks.postprocess.allocations.modelsdata;
+
+import java.io.IOException;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import multipacks.bundling.BundleResult;
+import multipacks.bundling.PackagingFailException;
+import multipacks.postprocess.PostProcessPass;
+import multipacks.utils.ResourcePath;
+import multipacks.utils.Selects;
+import multipacks.utils.logging.AbstractMPLogger;
+import multipacks.vfs.Path;
+import multipacks.vfs.VirtualFs;
+
+public class CustomModelsPass extends PostProcessPass {
+	private Path from;
+	private ModelDataAllocationSpace[] allocateOutOfSpace;
+
+	public CustomModelsPass(JsonObject config) {
+		from = new Path(Selects.nonNull(config.get("from"), "'from' is empty").getAsString());
+		if (config.has("outOfSpace")) {
+			JsonArray outOfSpace = config.get("outOfSpace").getAsJsonArray();
+			allocateOutOfSpace = new ModelDataAllocationSpace[outOfSpace.size()];
+			for (int i = 0; i < allocateOutOfSpace.length; i++) allocateOutOfSpace[i] = new ModelDataAllocationSpace(outOfSpace.get(i).getAsJsonObject());
+		}
+	}
+
+	@Override
+	public void apply(VirtualFs fs, BundleResult result, AbstractMPLogger logger) throws IOException {
+		ModelDataAllocator allocator = result.getOrCreate(ModelDataAllocator.class, ModelDataAllocator::new);
+		boolean alreadyAdded = false;
+
+		for (Path p : fs.ls(from)) {
+			AllocatedModelData data = allocator.allocateNew(fs, p);
+			if (data == null) {
+				if (alreadyAdded || allocateOutOfSpace.length == 0) throw new PackagingFailException("Custom Model Data: Out of space to allocate new model id");
+				logger.info("Custom Model Data: Adding " + allocateOutOfSpace.length + " space" + (allocateOutOfSpace.length == 1? "" : "s"));
+				for (ModelDataAllocationSpace s : allocateOutOfSpace) allocator.add(s);
+				data = allocator.allocateNew(fs, p);
+				alreadyAdded = true;
+			}
+			if (data == null) {
+				// 2nd try: We ran out of space again :(
+				throw new PackagingFailException("Custom Model Data: Out of space to allocate new model id. Maybe you need to allocate more...");
+			}
+
+			try {
+				JsonObject json = fs.readJson(p).getAsJsonObject();
+				ResourcePath id = Selects.getChain(json.get("multipacks:id"), j -> new ResourcePath(j.getAsString()), null);
+				if (id == null) logger.warning("Custom Model Data: " + p + ": Missing 'multipacks:id' field");
+				else allocator.mappedModels.put(id, data);
+			} catch (Exception e) {
+				e.printStackTrace();
+				logger.warning("Custom Model Data: " + p + ": Not a valid JSON file");
+			}
+		}
+	}
+}

--- a/multipacks-engine/src/main/java/multipacks/postprocess/allocations/modelsdata/ModelDataAllocationSpace.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/allocations/modelsdata/ModelDataAllocationSpace.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonObject;
 
 import multipacks.postprocess.allocations.AllocationSpace;
 import multipacks.utils.ResourcePath;
+import multipacks.utils.Selects;
 import multipacks.vfs.Path;
 import multipacks.vfs.VirtualFs;
 
@@ -33,6 +34,12 @@ public class ModelDataAllocationSpace extends AllocationSpace<AllocatedModelData
 		this.itemId = itemId;
 		this.startId = startId;
 		this.endId = endId;
+	}
+
+	public ModelDataAllocationSpace(JsonObject json) {
+		itemId = new ResourcePath(Selects.nonNull(json.get("id"), "'id' is empty").getAsString());
+		startId = Selects.getChain(json.get("start"), j -> j.getAsInt(), 1);
+		endId = Selects.getChain(json.get("end"), j -> j.getAsInt(), startId);
 	}
 
 	@Override

--- a/multipacks-engine/src/main/java/multipacks/postprocess/allocations/modelsdata/ModelDataAllocationSpace.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/allocations/modelsdata/ModelDataAllocationSpace.java
@@ -48,6 +48,8 @@ public class ModelDataAllocationSpace extends AllocationSpace<AllocatedModelData
 	@Override
 	public AllocatedModelData allocate(int index, VirtualFs fs, Path model) throws IOException {
 		int modelId = startId + index;
+		String[] split = model.fileName().split("\\.");
+		if (split.length > 1) model = new Path(model.toString().substring(0, model.toString().length() - split[split.length - 1].length() - 1));
 
 		Path modelPath = new Path("assets", itemId.namespace, "models", "item", itemId.path + ".json");
 		JsonObject json = fs.isExists(modelPath)? fs.readJson(modelPath).getAsJsonObject() : new JsonObject();

--- a/multipacks-engine/src/main/java/multipacks/postprocess/allocations/modelsdata/ModelDataAllocationSpace.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/allocations/modelsdata/ModelDataAllocationSpace.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020-2022 MangoPlex
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package multipacks.postprocess.allocations.modelsdata;
+
+import java.io.IOException;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import multipacks.postprocess.allocations.AllocationSpace;
+import multipacks.utils.ResourcePath;
+import multipacks.vfs.Path;
+import multipacks.vfs.VirtualFs;
+
+public class ModelDataAllocationSpace extends AllocationSpace<AllocatedModelData, Path> {
+	public ResourcePath itemId;
+	public int startId, endId;
+
+	public ModelDataAllocationSpace(ResourcePath itemId, int startId, int endId) {
+		this.itemId = itemId;
+		this.startId = startId;
+		this.endId = endId;
+	}
+
+	@Override
+	public int size() { return endId - startId + 1; }
+
+	@Override
+	public AllocatedModelData allocate(int index, VirtualFs fs, Path model) throws IOException {
+		int modelId = startId + index;
+
+		Path modelPath = new Path("assets", itemId.namespace, "models", "item", itemId.path + ".json");
+		JsonObject json = fs.isExists(modelPath)? fs.readJson(modelPath).getAsJsonObject() : new JsonObject();
+
+		if (!fs.isExists(modelPath)) {
+			// TODO: allow modifying these values from json
+			json.addProperty("parent", "item/handheld");
+
+			JsonObject textures = new JsonObject();
+			textures.addProperty("layer0", itemId.namespace + ":" + "item/" + itemId.path);
+			json.add("textures", textures);
+		}
+
+		JsonArray overrides = json.has("overrides")? json.get("overrides").getAsJsonArray() : new JsonArray();
+		JsonObject override = new JsonObject();
+		JsonObject predicate = new JsonObject();
+		predicate.addProperty("custom_model_data", modelId);
+		override.add("predicate", predicate);
+		override.addProperty("model", model.toNamespacedKey(3).toString());
+		overrides.add(override);
+		json.add("overrides", overrides);
+		fs.writeJson(modelPath, json);
+
+		return new AllocatedModelData(itemId, modelId);
+	}
+}

--- a/multipacks-engine/src/main/java/multipacks/postprocess/allocations/modelsdata/ModelDataAllocator.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/allocations/modelsdata/ModelDataAllocator.java
@@ -15,8 +15,18 @@
  */
 package multipacks.postprocess.allocations.modelsdata;
 
+import java.util.HashMap;
+
 import multipacks.postprocess.allocations.Allocator;
+import multipacks.utils.ResourcePath;
 import multipacks.vfs.Path;
 
 public class ModelDataAllocator extends Allocator<AllocatedModelData, Path> {
+	/**
+	 * Mapped models with its named id assigned to allocated model numerical id. An use case would be a custom
+	 * Spigot plugin that reads all mapped models and convert them to numerical id, something like <code>"/give
+	 * player ${model(namespace:id).gameId}{CustomModelData:${model(namespace:id).modelId}}"</code>. Currently
+	 * this map is limited to calls on {@link CustomModelsPass}. 
+	 */
+	public final HashMap<ResourcePath, AllocatedModelData> mappedModels = new HashMap<>();
 }

--- a/multipacks-engine/src/main/java/multipacks/postprocess/allocations/modelsdata/ModelDataAllocator.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/allocations/modelsdata/ModelDataAllocator.java
@@ -13,29 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package multipacks.bundling;
-
-import java.util.HashMap;
-import java.util.function.Supplier;
+package multipacks.postprocess.allocations.modelsdata;
 
 import multipacks.postprocess.allocations.Allocator;
-import multipacks.vfs.VirtualFs;
+import multipacks.vfs.Path;
 
-public class BundleResult {
-	private final HashMap<Class<?>, Object> transformResults = new HashMap<>();
-	public VirtualFs files;
-
-	@SuppressWarnings("unchecked")
-	public <T> T getOrCreate(Class<T> clazz, Supplier<T> creator) {
-		if (clazz == Allocator.class) throw new IllegalArgumentException("Cannot take in Allocator class. Please extends Allocator.");
-
-		Object obj = transformResults.get(clazz);
-
-		if (obj == null) {
-			obj = creator.get();
-			transformResults.put(clazz, obj);
-		}
-
-		return (T) obj;
-	}
+public class ModelDataAllocator extends Allocator<AllocatedModelData, Path> {
 }


### PR DESCRIPTION
This PR add contents allocations API, which allow multiple post processing passes to allocate object, avoiding as much conflicts as possible. This PR also add custom models data allocation, which allow user to automatically assign JSON models with ``CustomModelData`` id:

```json
{
    "type": "custom-models",
    "from": "assets/namespace/models/items",
    "outOfSpace": {
        "//": "outOfSpace is optional: This JSON object is used to add more space when the model ids allocator ran out of space",
        "id": "minecraft:diamond_hoe",
        "from": 1, "to": 10000000, "//": "ids must starts from 1"
    }
}
```