### PR TITLE
Fix virtual filesystem ls not returning the file when querying...

### DIFF
--- a/multipacks-engine/src/main/java/multipacks/postprocess/basic/CopyPass.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/basic/CopyPass.java
@@ -43,9 +43,15 @@ public class CopyPass extends PostProcessPass {
 	@Override
 	public void apply(VirtualFs fs, BundleResult result, AbstractMPLogger logger) throws IOException {
 		for (Path pFrom : fs.ls(from)) {
+			byte[] bs = fs.read(pFrom);
+
+			if (pFrom.toString().equals(from.toString())) {
+				fs.write(to, bs);
+				return;
+			}
+
 			String tail = pFrom.toString().substring(from.toString().length() + 1);
 			Path pTo = Path.join(to, new Path(tail));
-			byte[] bs = fs.read(pFrom);
 			fs.write(pTo, bs);
 		}
 	}

--- a/multipacks-engine/src/main/java/multipacks/postprocess/basic/MovePass.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/basic/MovePass.java
@@ -43,9 +43,16 @@ public class MovePass extends PostProcessPass {
 	@Override
 	public void apply(VirtualFs fs, BundleResult result, AbstractMPLogger logger) throws IOException {
 		for (Path pFrom : fs.ls(from)) {
+			byte[] bs = fs.read(pFrom);
+
+			if (pFrom.toString().equals(from.toString())) {
+				fs.write(to, bs);
+				fs.delete(from);
+				return;
+			}
+
 			String tail = pFrom.toString().substring(from.toString().length() + 1);
 			Path pTo = Path.join(to, new Path(tail));
-			byte[] bs = fs.read(pFrom);
 			fs.write(pTo, bs);
 			fs.delete(pFrom);
 		}

--- a/multipacks-engine/src/main/java/multipacks/vfs/VirtualFs.java
+++ b/multipacks-engine/src/main/java/multipacks/vfs/VirtualFs.java
@@ -119,6 +119,11 @@ public class VirtualFs {
 	public Path[] ls(Path dir) {
 		List<Path> l = new ArrayList<>();
 		for (Path p : emulatedFs.keySet()) if (dir.isParentOf(p)) l.add(p);
+		if (emulatedFs.containsKey(dir)) {
+			// Not a directory!
+			return new Path[] { dir };
+		}
+
 		if (root != null) {
 			File underlyingDir = dir.joinWith(root);
 			if (underlyingDir.exists()) lsExpand(underlyingDir, dir, l);


### PR DESCRIPTION
This PR fix ``fs.ls(path)`` does not returns ``[path]``, with ``path`` points toward the file instead of directory. This PR also fix coping and moving single file inside virtual file system issue.