### PR TITLE
Prevent reallocating model ID when using dependencies

### DIFF
--- a/multipacks-engine/src/main/java/multipacks/postprocess/allocations/modelsdata/CustomModelsPass.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/allocations/modelsdata/CustomModelsPass.java
@@ -48,6 +48,8 @@ public class CustomModelsPass extends PostProcessPass {
 		boolean alreadyAdded = false;
 
 		for (Path p : fs.ls(from)) {
+			if (allocator.isAlreadyAllocated(p)) continue;
+
 			AllocatedModelData data = allocator.allocateNew(fs, p);
 			if (data == null) {
 				if (alreadyAdded || allocateOutOfSpace.length == 0) throw new PackagingFailException("Custom Model Data: Out of space to allocate new model id");

--- a/multipacks-engine/src/main/java/multipacks/postprocess/allocations/modelsdata/ModelDataAllocator.java
+++ b/multipacks-engine/src/main/java/multipacks/postprocess/allocations/modelsdata/ModelDataAllocator.java
@@ -15,11 +15,13 @@
  */
 package multipacks.postprocess.allocations.modelsdata;
 
+import java.io.IOException;
 import java.util.HashMap;
 
 import multipacks.postprocess.allocations.Allocator;
 import multipacks.utils.ResourcePath;
 import multipacks.vfs.Path;
+import multipacks.vfs.VirtualFs;
 
 public class ModelDataAllocator extends Allocator<AllocatedModelData, Path> {
 	/**
@@ -29,4 +31,17 @@ public class ModelDataAllocator extends Allocator<AllocatedModelData, Path> {
 	 * this map is limited to calls on {@link CustomModelsPass}. 
 	 */
 	public final HashMap<ResourcePath, AllocatedModelData> mappedModels = new HashMap<>();
+
+	private HashMap<Path, AllocatedModelData> allocatedPaths = new HashMap<>();
+
+	public boolean isAlreadyAllocated(Path path) {
+		return allocatedPaths.containsKey(path);
+	}
+
+	@Override
+	public AllocatedModelData allocateNew(VirtualFs fs, Path data) throws IOException {
+		AllocatedModelData allocated = allocatedPaths.get(data);
+		if (allocated == null) allocatedPaths.put(data, allocated = super.allocateNew(fs, data));
+		return allocated;
+	}
 }


### PR DESCRIPTION
Some advanced users may split their Multipacks project into multiple packs, something like this directory structure:
```
myproject/
+- myproject-artifacts/
+- myproject-tools/
+- myproject-misc/
+- multipacks.json
```

Each dependencies inside ``myproject/`` exports its contents to parent pack VFS, and sometimes those dependencies might have ``custom-models`` post processing pass, which might cause duplicated entries inside ``assets/minecraft/models/item/<id>.json`` (which is also visible if you don't give your model an ID):
```console
$ multipacks-cli pack build claymores/
claymores/nouwu Local file: ./claymores-nouwu -> 1.0.0
Custom Model Data: Adding 1 space
Custom Model Data: assets/claymores/models/nouwu.json: Missing 'multipacks:id' field
Custom Model Data: assets/claymores/models/nouwu.json: Missing 'multipacks:id' field
Custom Model Data: assets/claymores/models/uwu.json: Missing 'multipacks:id' field
Done.
```

This PR solves this issue by storing allocated model IDs inside internal ``HashMap`` and only returns previously allocated ID if the file path is already allocated.